### PR TITLE
Update database.php

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -1,6 +1,6 @@
 <?php
 
-$url = parse_url(getenv("CLEARDB_DATABASE_URL"));
+$url = parse_url(getenv("DATABASE_URL"));
 
 $host = $url["host"];
 $username = $url["user"];


### PR DESCRIPTION
https://devcenter.heroku.com/changelog-items/438 

As of now, if a Postgres add-on is provisioned to an app that does not have a DATABASE_URL config key, DATABASE_URL will be automatically set to the URL of the provisioned database in addition to adding the HEROKU_POSTGRESQL_COLOR_URL config.
$ heroku addons:add heroku-postgresql
...

$ heroku config
=== example-app Config Vars
DATABASE_URL:               postgres://{user}:{password}@{hostname}:{port}/{database-name}
HEROKU_POSTGRESQL_AQUA_URL: postgres://{user}:{password}@{hostname}:{port}/{database-name}